### PR TITLE
WorldEdit adapters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mikeprimm</groupId>
     <artifactId>SchematicBrush</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mikeprimm</groupId>
     <artifactId>SchematicBrush</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <build>
         <plugins>
             <plugin>
@@ -50,9 +50,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-forge-mc1.10.2</artifactId>
+            <version>6.1.5</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
-            <version>5.0.0-20160824.073152-102</version>
+            <version>5.2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/mikeprimm/schematicbrush/SchematicBrush.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/SchematicBrush.java
@@ -30,6 +30,7 @@ import com.sk89q.worldedit.session.PasteBuilder;
 import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.util.io.file.FilenameException;
 import com.sk89q.worldedit.world.registry.WorldData;
+import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
@@ -50,7 +51,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -313,11 +313,17 @@ public class SchematicBrush {
     @Inject
     private Logger log;
 
-    private Adapter adapter = player -> Optional.empty();
+    private Adapter adapter = AdapterFactory.DUMMY;
 
     @Listener
     public void onEnable(GameInitializationEvent event) {
-        this.adapter = AdapterFactory.getAdapter();
+        adapter = AdapterFactory.getAdapter();
+
+        if (adapter.isPresent()) {
+            log.info("Successfully created adapter for the current version of WorldEdit");
+        } else {
+            log.info("Could not create an adapter for the current version of WorldEdit");
+        }
 
         if (!Files.exists(Paths.get(config.getAbsolutePath()))) {
             try {

--- a/src/main/java/com/mikeprimm/schematicbrush/SchematicBrush.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/SchematicBrush.java
@@ -903,8 +903,7 @@ public class SchematicBrush {
         Gson g = new Gson();
         try {
             String s = new String(Files.readAllBytes(Paths.get(config.getAbsolutePath())));
-            Type type = new TypeToken<Map<String, SchematicDef>>() {
-            }.getType();
+            Type type = new TypeToken<LinkedHashMap<String, SchematicDef>>(){}.getType();
             LinkedHashMap obj = g.fromJson(s, type);
             sets = new HashMap<>(obj == null ? Collections.EMPTY_MAP : obj);
         } catch (IOException e) {

--- a/src/main/java/com/mikeprimm/schematicbrush/SchematicBrush.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/SchematicBrush.java
@@ -221,15 +221,27 @@ public class SchematicBrush {
     private HashMap<String, SchematicSet> sets = new HashMap<String, SchematicSet>();
 
     public class SchematicBrushInstance implements Brush {
+
+        private static final long DELAY = 500;
+
         SchematicSet set;
         Player player;
         boolean skipair;
         boolean replaceall;
         int yoff;
         Placement place;
+        long time = 0;
 
         @Override
         public void build(EditSession editsession, Vector pos, com.sk89q.worldedit.function.pattern.Pattern mat, double size) throws MaxChangedBlocksException {
+            long now = System.currentTimeMillis();
+            if (now - time < DELAY) {
+                // prevent accidental spam-pasting?
+                return;
+            }
+
+            time = now;
+
             SchematicDef def = set.getRandomSchematic();    // Pick schematic from set
             if (def == null) return;
 

--- a/src/main/java/com/mikeprimm/schematicbrush/adapter/Adapter.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/adapter/Adapter.java
@@ -1,0 +1,13 @@
+package com.mikeprimm.schematicbrush.adapter;
+
+import com.sk89q.worldedit.entity.Player;
+
+import java.util.Optional;
+
+/**
+ * @author dags <dags@dags.me>
+ */
+public interface Adapter {
+
+    Optional<Player> wrapPlayer(org.spongepowered.api.entity.living.player.Player player);
+}

--- a/src/main/java/com/mikeprimm/schematicbrush/adapter/Adapter.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/adapter/Adapter.java
@@ -9,5 +9,7 @@ import java.util.Optional;
  */
 public interface Adapter {
 
+    boolean isPresent();
+
     Optional<Player> wrapPlayer(org.spongepowered.api.entity.living.player.Player player);
 }

--- a/src/main/java/com/mikeprimm/schematicbrush/adapter/AdapterFactory.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/adapter/AdapterFactory.java
@@ -1,24 +1,24 @@
 package com.mikeprimm.schematicbrush.adapter;
 
-import java.util.Optional;
-
 /**
  * @author dags <dags@dags.me>
  */
 public class AdapterFactory {
 
+    public static final Adapter DUMMY = new DummyAdapter();
+
     public static Adapter getAdapter() {
         Adapter forge = get("com.sk89q.worldedit.forge.ForgeWorldEdit", "com.mikeprimm.schematicbrush.adapter.ForgeAdapter");
-        if (forge != null) {
+        if (forge != null && forge.isPresent()) {
             return forge;
         }
 
         Adapter sponge = get("com.sk89q.worldedit.sponge.SpongeWorldEdit", "com.mikeprimm.schematicbrush.adapter.SpongeAdapter");
-        if (sponge != null) {
+        if (sponge != null && sponge.isPresent()) {
             return sponge;
         }
 
-        return player -> Optional.empty();
+        return DUMMY;
     }
 
     private static Adapter get(String testFor, String adapter) {
@@ -27,7 +27,6 @@ public class AdapterFactory {
             Class<?> target = Class.forName(adapter);
             return Adapter.class.cast(target.newInstance());
         } catch (Throwable t) {
-            t.printStackTrace();
             return null;
         }
     }

--- a/src/main/java/com/mikeprimm/schematicbrush/adapter/AdapterFactory.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/adapter/AdapterFactory.java
@@ -1,0 +1,34 @@
+package com.mikeprimm.schematicbrush.adapter;
+
+import java.util.Optional;
+
+/**
+ * @author dags <dags@dags.me>
+ */
+public class AdapterFactory {
+
+    public static Adapter getAdapter() {
+        Adapter forge = get("com.sk89q.worldedit.forge.ForgeWorldEdit", "com.mikeprimm.schematicbrush.adapter.ForgeAdapter");
+        if (forge != null) {
+            return forge;
+        }
+
+        Adapter sponge = get("com.sk89q.worldedit.sponge.SpongeWorldEdit", "com.mikeprimm.schematicbrush.adapter.SpongeAdapter");
+        if (sponge != null) {
+            return sponge;
+        }
+
+        return player -> Optional.empty();
+    }
+
+    private static Adapter get(String testFor, String adapter) {
+        try {
+            Class.forName(testFor);
+            Class<?> target = Class.forName(adapter);
+            return Adapter.class.cast(target.newInstance());
+        } catch (Throwable t) {
+            t.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/mikeprimm/schematicbrush/adapter/DummyAdapter.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/adapter/DummyAdapter.java
@@ -1,22 +1,20 @@
 package com.mikeprimm.schematicbrush.adapter;
 
 import com.sk89q.worldedit.entity.Player;
-import com.sk89q.worldedit.sponge.SpongeWorldEdit;
 
 import java.util.Optional;
 
 /**
  * @author dags <dags@dags.me>
  */
-public class SpongeAdapter implements Adapter {
-
+public class DummyAdapter implements Adapter {
     @Override
     public boolean isPresent() {
-        return true;
+        return false;
     }
 
     @Override
     public Optional<Player> wrapPlayer(org.spongepowered.api.entity.living.player.Player player) {
-        return Optional.of(SpongeWorldEdit.inst().wrapPlayer(player));
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/mikeprimm/schematicbrush/adapter/ForgeAdapter.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/adapter/ForgeAdapter.java
@@ -1,0 +1,44 @@
+package com.mikeprimm.schematicbrush.adapter;
+
+import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.forge.ForgeWorldEdit;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+/**
+ * @author dags <dags@dags.me>
+ */
+public class ForgeAdapter implements Adapter {
+
+    private final Method wrap;
+
+    public ForgeAdapter() {
+        Method wrap;
+        try {
+            wrap = ForgeWorldEdit.class.getDeclaredMethod("wrap");
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            wrap = null;
+        }
+        this.wrap = wrap;
+    }
+
+    @Override
+    public Optional<Player> wrapPlayer(org.spongepowered.api.entity.living.player.Player player) {
+        if (wrap != null) {
+            try {
+                // Not the best, but saves having to depend on forge/minecraft source to call ForgeWorldEdit.wrap(EntityPlayerMP)
+                // Sponge's Player interface is 'mixed into' EntityPlayerMP so this invocation should be valid
+                Object wrapped = wrap.invoke(ForgeWorldEdit.inst, player);
+                if (wrapped != null) {
+                    return Optional.of(Player.class.cast(wrapped));
+                }
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/mikeprimm/schematicbrush/adapter/ForgeAdapter.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/adapter/ForgeAdapter.java
@@ -5,6 +5,7 @@ import com.sk89q.worldedit.forge.ForgeWorldEdit;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Optional;
 
 /**
@@ -15,19 +16,26 @@ public class ForgeAdapter implements Adapter {
     private final Method wrap;
 
     public ForgeAdapter() {
-        Method wrap;
-        try {
-            wrap = ForgeWorldEdit.class.getDeclaredMethod("wrap");
-        } catch (NoSuchMethodException e) {
-            e.printStackTrace();
-            wrap = null;
+        Method target = null;
+
+        for (Method method : ForgeWorldEdit.class.getMethods()) {
+            if (method.getName().equals("wrap")) {
+                target = method;
+                break;
+            }
         }
-        this.wrap = wrap;
+
+        this.wrap = target;
+    }
+
+    @Override
+    public boolean isPresent() {
+        return wrap != null;
     }
 
     @Override
     public Optional<Player> wrapPlayer(org.spongepowered.api.entity.living.player.Player player) {
-        if (wrap != null) {
+        if (isPresent()) {
             try {
                 // Not the best, but saves having to depend on forge/minecraft source to call ForgeWorldEdit.wrap(EntityPlayerMP)
                 // Sponge's Player interface is 'mixed into' EntityPlayerMP so this invocation should be valid

--- a/src/main/java/com/mikeprimm/schematicbrush/adapter/SpongeAdapter.java
+++ b/src/main/java/com/mikeprimm/schematicbrush/adapter/SpongeAdapter.java
@@ -1,0 +1,17 @@
+package com.mikeprimm.schematicbrush.adapter;
+
+import com.sk89q.worldedit.entity.Player;
+import com.sk89q.worldedit.sponge.SpongeWorldEdit;
+
+import java.util.Optional;
+
+/**
+ * @author dags <dags@dags.me>
+ */
+public class SpongeAdapter implements Adapter {
+
+    @Override
+    public Optional<Player> wrapPlayer(org.spongepowered.api.entity.living.player.Player player) {
+        return Optional.of(SpongeWorldEdit.inst().wrapPlayer(player));
+    }
+}


### PR DESCRIPTION
The main change in this PR allows the plugin to be used alongside WEForge _or_ WESponge by providing an adapter that handles wrapping the Sponge Player into the appropriate WorldEdit Player implementation.

It also includes a couple of minor changes to work around some sponge quirks we were running into that may or may not be relevant on api 7 (see commit messages)